### PR TITLE
Fix scrolling in blueprint and sidepanel

### DIFF
--- a/gg5e_mm.css
+++ b/gg5e_mm.css
@@ -245,7 +245,7 @@
 .gg5e-mm-blueprint {
   background: white;
   padding: 0.125rem;
-  overflow: hidden;
+  overflow: auto;
   flex-grow: 1;
   display: flex;
   flex-direction: column;
@@ -2248,7 +2248,7 @@
     margin-top: -1rem;
     border-radius: 1rem;
     padding: 1rem;
-    overflow-y: overlay;
+    overflow-y: auto;
     flex-grow: 1;
     background: var(--color-primary-tint-2); }
     .monster--vanity .monster__body > * + * {

--- a/stylesheets/components/_blueprint.scss
+++ b/stylesheets/components/_blueprint.scss
@@ -1,7 +1,7 @@
 .gg5e-mm-blueprint {
 	background: white;
 	padding: 0.125rem;
-	overflow: hidden;
+	overflow: auto;
 	flex-grow: 1;
 	display: flex;
 	flex-direction: column;

--- a/stylesheets/monsters/_monster--vanity.scss
+++ b/stylesheets/monsters/_monster--vanity.scss
@@ -104,7 +104,7 @@
 		margin-top: -1rem;
 		border-radius: 1rem;
 		padding: 1rem;
-		overflow-y: overlay;
+		overflow-y: auto;
 		flex-grow: 1;
 		background: var(--color-primary-tint-2);
 


### PR DESCRIPTION
When i tried using the latest version of your plugin, the scrolling didnt work in the character sheet and in the configuration side bar. The issue seems to be with the overflow css tags, where one was set to hidden, which might have been an intentional change? and the other was set to overlay. Ive changed both these tags to auto in order to allow for scrolling. [This page](https://caniuse.com/css-overflow-overlay) details some more about using overlay, which is apparently non standard, and not supported in firefox, which is the browser that i am using. Ive tested these changes locally, and they seem to fix the issue, though i have not tested this too much.